### PR TITLE
Fix for incorrect layer URL

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -675,7 +675,7 @@ class Catalog:
             raise FailedRequestError(r.text)
 
     def publish_featuretype(self, name, store, native_crs, srs=None,
-                            jdbc_virtual_table=None):
+                            jdbc_virtual_table=None, native_bbox=None):
         """
         Publish a featuretype from data in an existing store
         """
@@ -691,6 +691,8 @@ class Catalog:
         feature_type.dirty['name'] = name
         feature_type.dirty['srs'] = srs
         feature_type.dirty['nativeCRS'] = native_crs
+        if native_bbox is not None:
+            feature_type.native_bbox = native_bbox
         feature_type.enabled = True
         feature_type.title = name
         headers = {

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -713,6 +713,8 @@ class Catalog:
         # What is the use of this request?
         r = self.session.post(resource_url, data=feature_type.message(),
                               headers=headers, params=params)
+        if r.status_code < 200 or r.status_code > 299:
+            raise UploadError(r.text)
         feature_type.fetch()
         return feature_type
 

--- a/src/geoserver/layer.py
+++ b/src/geoserver/layer.py
@@ -84,7 +84,7 @@ class Layer(ResourceInfo):
     def href(self):
         return urljoin(
             self.catalog.service_url,
-            "layer/{}.xml".format(self.name)
+            "layers/{}.xml".format(self.name)
         )
 
     @property

--- a/src/geoserver/support.py
+++ b/src/geoserver/support.py
@@ -164,7 +164,7 @@ def write_string(name):
 def write_metadata(name):
     def write(builder, metadata):
         builder.start(name, dict())
-        for k, v in metadata.iteritems():
+        for k, v in metadata.items():
             builder.start("entry", dict(key=k))
             if k in ['time', 'elevation'] or k.startswith('custom_dimension'):
                 dimension_info(builder, v)

--- a/src/geoserver/support.py
+++ b/src/geoserver/support.py
@@ -133,15 +133,19 @@ class DimensionInfo:
 
 def xml_property(path, converter=lambda x: x.text, default=None):
     def getter(self):
-        if path in self.dirty:
-            return self.dirty[path]
-        else:
-            if self.dom is None:
-                self.fetch()
-            node = self.dom.find(path)
-            if node is not None:
-                return converter(self.dom.find(path))
-            return default
+        try:
+            if path in self.dirty:
+                return self.dirty[path]
+            else:
+                if self.dom is None:
+                    self.fetch()
+                node = self.dom.find(path)
+                if node is not None:
+                    return converter(self.dom.find(path))
+                return default
+        except Exception as e:
+            raise AttributeError(e)
+        
 
     def setter(self, value):
         self.dirty[path] = value


### PR DESCRIPTION
Looks like a typo was introduced in the original py3 conversion changeset (d32ebb0934c04f6b28d92ec0aaf967fda66ce07a) - "layers" -> "layer" on the href call for Layer. Causes all calls to Layer to fail silently for me, which does some very interesting things... Attached changeset just adds the missing s.
