### PR TITLE
Fix for incorrect style url

### DIFF
--- a/src/geoserver/style.py
+++ b/src/geoserver/style.py
@@ -50,7 +50,7 @@ class Style(ResourceInfo):
         if not create:
             url_part += "{}{}".format(self.name, extension)
         else:
-            url_part = "?name={}".format(self.name)
+            url_part += "?name={}".format(self.name)
         if self.workspace is not None:
             url_part = "workspaces/{}/{}".format(
                 getattr(self.workspace, 'name', self.workspace),

--- a/src/geoserver/style.py
+++ b/src/geoserver/style.py
@@ -46,7 +46,7 @@ class Style(ResourceInfo):
         return Style.content_types[self.style_format]
 
     def _build_href(self, extension, create=False):
-        url_part = "styles"
+        url_part = "styles/"
         if not create:
             url_part += "{}{}".format(self.name, extension)
         else:


### PR DESCRIPTION
Looks like the urls constructed for managing styles missed a slash. Also when creating a new style, the constructed path was overwritten.