### PR TITLE
fixed naming irregularities for unit_symbol vs unitSymbol

### DIFF
--- a/src/geoserver/support.py
+++ b/src/geoserver/support.py
@@ -493,9 +493,9 @@ def dimension_info(builder, metadata):
             builder.start("units", dict())
             builder.data(metadata.units)
             builder.end("units")
-        if metadata.unitSymbol is not None:
+        if metadata.unit_symbol is not None:
             builder.start("unitSymbol", dict())
-            builder.data(metadata.unitSymbol)
+            builder.data(metadata.unit_symbol)
             builder.end("unitSymbol")
         if metadata.strategy is not None:
             builder.start("defaultValue", dict())


### PR DESCRIPTION
the property unit_symbol of the class DimensionInfo was renamed (compared to boundlessgeo repo), which caused the request metadata.unitSymbol to fail