### PR TITLE
Fixed mosaic_delete_granule method

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -658,10 +658,10 @@ class Catalog:
         """
         params = dict()
         p = "workspaces/{}/coveragestores/{}/coverages/{}"\
-            + "/index/granule/{}.json"
+            + "/index/granules/{}.json"
         cs_url = urljoin(
             self.service_url,
-            p.format(store.workspace, store.name, coverage, granule_id)
+            p.format(store.workspace.name, store.name, coverage, granule_id)
         )
         # DELETE /workspaces/<ws>/coveragestores/<name>/coverages/<coverage>/index/granules/<granule_id>.json
         headers = {


### PR DESCRIPTION
Url is created using `granule` instead `granules` [#L661](https://github.com/dimitri-justeau/gsconfig-py3/blob/master/src/geoserver/catalog.py#L661)
Get the `workspace` instead the `workspace.name` [#L664](https://github.com/dimitri-justeau/gsconfig-py3/blob/master/src/geoserver/catalog.py#L664)